### PR TITLE
chore: skip ecr login and push for docker build usage

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,10 @@ inputs:
     description: "Skip the AWS setup process if it has been run in the same job already"
     required: false
     default: "false"
+  skip-aws-push:
+    description: "Skip pushing the container image to ECR"
+    required: false
+    default: "false"
   target:
     description: ""
     default: "prod"
@@ -62,6 +66,7 @@ runs:
         docker build --file ${{ inputs.build-context }}/${{ inputs.dockerfile }} --target ${{ inputs.target }} --build-arg FURY_AUTH_PULL=${{ inputs.fury-token }} ${{ inputs.build-context }}
 
     - name: Push image to Amazon ECR
+      if: ${{ inputs.skip-aws-push == 'false' }}
       shell: bash
       run: |
         set +e

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,7 @@ runs:
         aws-region: ${{ inputs.aws-region }}
 
     - name: Login to Amazon ECR
+      if: ${{ inputs.skip-aws-push == 'false' }}
       uses: aws-actions/amazon-ecr-login@v1
       id: login_ecr
 


### PR DESCRIPTION
## Description

Skip ECR login and push for docker build re-use.

## Related Issue(s)

- <https://jira.arubanetworks.com/browse/UXI-1923>
